### PR TITLE
Convert Plugin to Python 3 to be able to run on Indigo 2022.2+

### DIFF
--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>PluginVersion</key>
-	<string>0.3.2</string>
+	<string>0.4.0</string>
 	<key>ServerApiVersion</key>
-	<string>2.0</string>
+	<string>3.0</string>
 	<key>IwsApiVersion</key>
 	<string>1.0.0</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
Convert plugin to Python 3.

The main changes: Converting to 'f' strings, converting u"abc" -> "abc", changing filter() processing to cater for Python 3 return ing a filter where previously it returned a list., minor coding and grammatical corrections.

Update Plugin Version to 0.4.0
Set required Indigo Server API version to 3.0